### PR TITLE
BUGFIX: fix swift package error and build erros

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -206,13 +206,13 @@ let package = Package(
 
         .target(
             name: "Fetch",
-            // dependencies: [
-            //     .product(
-            //         name: "JavaScriptKit",
-            //         package: "JavaScriptKit",
-            //         condition: .when(platforms: [.wasi])
-            //     )
-            // ]
+            dependencies: [
+                .product(
+                    name: "JavaScriptKit",
+                    package: "JavaScriptKit",
+                    condition: .when(platforms: [.wasi])
+                )
+            ]
         ),
 
         .target(

--- a/Sources/Playground/Pages/Kit_Icons.swift
+++ b/Sources/Playground/Pages/Kit_Icons.swift
@@ -14,7 +14,7 @@ final class Kit_IconsState: State<Kit_Icons> {
             gridDelegate: SliverGridDelegateWithMaxCrossAxisExtent(
                 maxCrossAxisExtent: 120,
                 mainAxisSpacing: 10,
-                crossAxisSpacing: 10,
+                crossAxisSpacing: 10
             ),
             itemCount: LucideIcon.allIcons.count,
             itemBuilder: { context, index in

--- a/Sources/Shaft/Widgets/AppLifecycleListener.swift
+++ b/Sources/Shaft/Widgets/AppLifecycleListener.swift
@@ -262,7 +262,7 @@ private final class AppLifecycleListenerWidgetState: State<AppLifecycleListenerW
             onShow: widget.onShow,
             onPause: widget.onPause,
             onRestart: widget.onRestart,
-            onDetach: widget.onDetach,
+            onDetach: widget.onDetach
         )
     }
 
@@ -308,7 +308,7 @@ extension Widget {
         onShow: VoidCallback? = nil,
         onPause: VoidCallback? = nil,
         onRestart: VoidCallback? = nil,
-        onDetach: VoidCallback? = nil,
+        onDetach: VoidCallback? = nil
     ) -> Widget {
         return AppLifecycleListenerWidget(
             onResume: onResume,

--- a/Sources/Shaft/Widgets/Basic.swift
+++ b/Sources/Shaft/Widgets/Basic.swift
@@ -1355,7 +1355,7 @@ public class FractionallySizedBox: SingleChildRenderObjectWidget {
         return RenderFractionallySizedOverflowBox(
             widthFactor: widthFactor,
             heightFactor: heightFactor,
-            alignment: alignment,
+            alignment: alignment
             // textDirection: Directionality.maybeOf(context)
         )
     }

--- a/Sources/Shaft/Widgets/GestureDetector.swift
+++ b/Sources/Shaft/Widgets/GestureDetector.swift
@@ -1141,7 +1141,7 @@ extension Widget {
             onSecondaryTap: onSecondaryTap,
             onSecondaryTapDown: onSecondaryTapDown,
             onSecondaryTapUp: onSecondaryTapUp,
-            onSecondaryTapCancel: onSecondaryTapCancel,
+            onSecondaryTapCancel: onSecondaryTapCancel
         ) {
             self
         }

--- a/Sources/Shaft/Widgets/ScrollView.swift
+++ b/Sources/Shaft/Widgets/ScrollView.swift
@@ -1914,7 +1914,7 @@ public class GridView: BoxScrollView {
         restorationId: String? = nil,
         clipBehavior: Clip = .hardEdge,
         hitTestBehavior: HitTestBehavior = .opaque,
-        itemBuilder: @escaping NullableIndexedWidgetBuilder,
+        itemBuilder: @escaping NullableIndexedWidgetBuilder
     ) -> GridView {
         let delegate = SliverChildBuilderDelegate(
             itemBuilder,

--- a/Sources/ShaftLucide/LucideIcon.swift
+++ b/Sources/ShaftLucide/LucideIcon.swift
@@ -107,7 +107,7 @@ public class LucideIcon: StatelessWidget {
         let textStyle = TextStyle(
             color: effectiveColor,
             fontFamily: "lucide",
-            fontSize: size,
+            fontSize: size
         )
 
         var result: Widget = RichText(


### PR DESCRIPTION

```
➜  Shaft git:(main) swift --version
swift-driver version: 1.115 Apple Swift version 6.0.2 (swiftlang-6.0.2.1.2 clang-1600.0.26.4)
Target: arm64-apple-macosx15.0
```

swift package error:
```
➜  Shaft git:(main) swift package plugin setup-skia
error: 'shaft': Invalid manifest (compiled with: ["/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc", "-vfsoverlay", "/var/folders/7j/5sj42sxj6flc1nkf48wh3c_c0000gq/T/TemporaryDirectory.WeuDXi/vfs.yaml", "-L", "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/pm/ManifestAPI", "-lPackageDescription", "-Xlinker", "-rpath", "-Xlinker", "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/pm/ManifestAPI", "-target", "arm64-apple-macosx13.0", "-sdk", "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.1.sdk", "-F", "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks", "-I", "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/lib", "-L", "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/lib", "-swift-version", "5", "-I", "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/pm/ManifestAPI", "-sdk", "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.1.sdk", "-package-description-version", "5.9.0", "/Users/jiang/Shaft/Package.swift", "-o", "/var/folders/7j/5sj42sxj6flc1nkf48wh3c_c0000gq/T/TemporaryDirectory.TiB4iT/shaft-manifest"])
/Users/jiang/Shaft/Package.swift:216:9: error: unexpected ',' separator
214 |             //     )
215 |             // ]
216 |         ),
    |         `- error: unexpected ',' separator
217 | 
218 |         .target(
```

swift build error:
```
➜  Shaft git:(main) ✗ swift run Playground
Building for debugging...
error: emit-module command failed with exit code 1 (use -v to see invocation)
/Users/jiang/Shaft/Sources/Shaft/Widgets/AppLifecycleListener.swift:312:5: error: unexpected ',' separator
310 |         onRestart: VoidCallback? = nil,
311 |         onDetach: VoidCallback? = nil,
312 |     ) -> Widget {
    |     `- error: unexpected ',' separator
313 |         return AppLifecycleListenerWidget(
314 |             onResume: onResume,
```
